### PR TITLE
Add persistent resume store

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,7 +31,9 @@
     "react-day-picker": "^9.7.0",
     "react-dom": "^19.1.0",
     "tailwind-merge": "^3.3.0",
-    "tailwindcss": "^4.1.8"
+    "tailwindcss": "^4.1.8",
+    "zustand": "^4.5.2",
+    "idb-keyval": "^6.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,7 @@
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { useResumeStore } from "@/hooks/use-resume-store"
 
 export default function App() {
   const [currentView, setCurrentView] = useState("builder");
@@ -24,13 +26,58 @@ export default function App() {
 }
 
 function MyDataSection() {
-  return <div>📁 Personal data form goes here.</div>;
+  const { userInfo, setUserInfo } = useResumeStore()
+  const [name, setName] = useState(userInfo.name ?? "")
+  const [email, setEmail] = useState(userInfo.email ?? "")
+
+  return (
+    <div className="space-y-2 max-w-sm">
+      <Input
+        placeholder="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <Input
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <Button onClick={() => setUserInfo({ name, email })}>Save</Button>
+    </div>
+  )
 }
 
 function JobUploadSection() {
-  return <div>📄 Upload/paste job info and view history here.</div>;
+  const { jobInfo, setJobInfo } = useResumeStore()
+  const [description, setDescription] = useState(jobInfo.description ?? "")
+
+  return (
+    <div className="space-y-2 max-w-sm">
+      <textarea
+        className="w-full rounded border p-2 text-sm"
+        rows={6}
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+      />
+      <Button onClick={() => setJobInfo({ description })}>Save</Button>
+    </div>
+  )
 }
 
 function ResumeBuilderViewer() {
-  return <div className="text-gray-500 italic">🧾 Your resume will appear here once you add some data.</div>;
+  const { userInfo, jobInfo } = useResumeStore()
+
+  if (!Object.keys(userInfo).length && !Object.keys(jobInfo).length) {
+    return (
+      <div className="text-gray-500 italic">
+        🧾 Your resume will appear here once you add some data.
+      </div>
+    )
+  }
+
+  return (
+    <pre className="bg-muted p-4 rounded text-sm">
+      {JSON.stringify({ userInfo, jobInfo }, null, 2)}
+    </pre>
+  )
 }

--- a/apps/web/src/hooks/use-resume-store.ts
+++ b/apps/web/src/hooks/use-resume-store.ts
@@ -1,0 +1,57 @@
+import { create } from "zustand"
+import { persist, createJSONStorage } from "zustand/middleware"
+import { get, set, del } from "idb-keyval"
+
+export interface UserInfo {
+  name?: string
+  email?: string
+  [key: string]: unknown
+}
+
+export interface JobInfo {
+  description?: string
+  [key: string]: unknown
+}
+
+export interface ResumeContent {
+  [key: string]: unknown
+}
+
+export interface ResumeStore {
+  userInfo: UserInfo
+  jobInfo: JobInfo
+  content: ResumeContent
+  setUserInfo: (info: UserInfo) => void
+  setJobInfo: (info: JobInfo) => void
+  setContent: (data: ResumeContent) => void
+  reset: () => void
+}
+
+export const useResumeStore = create<ResumeStore>()(
+  persist<ResumeStore>(
+    (set) => ({
+      userInfo: {},
+      jobInfo: {},
+      content: {},
+      setUserInfo: (info) => set({ userInfo: { ...info } }),
+      setJobInfo: (info) => set({ jobInfo: { ...info } }),
+      setContent: (data) => set({ content: { ...data } }),
+      reset: () => set({ userInfo: {}, jobInfo: {}, content: {} }),
+    }),
+    {
+      name: "resumier-web-store",
+      storage: createJSONStorage(() => ({
+        async getItem(name: string) {
+          const value = await get(name)
+          return value ?? null
+        },
+        async setItem(name: string, value: unknown) {
+          await set(name, value)
+        },
+        async removeItem(name: string) {
+          await del(name)
+        },
+      })),
+    },
+  ),
+)


### PR DESCRIPTION
## Summary
- implement a global zustand store with IndexedDB persistence
- show how the store is used in the example app
- add zustand and idb-keyval deps

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Cannot find module 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_6846792326d483298efd3857a6360056