### PR TITLE
Add auto-assign PR author workflow

### DIFF
--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -1,0 +1,22 @@
+name: Auto assign PR author
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  add-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add PR author as assignee
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const author = context.payload.pull_request.user.login;
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              assignees: [author]
+            });
+


### PR DESCRIPTION
## Summary
- assign PR author as assignee automatically when a PR is opened

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467f8f36988329b1ceb0d89778b2bb