### PR TITLE
Fix dark theme for date inputs

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -118,3 +118,12 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Ensure native date pickers match the current theme */
+input[type="date"] {
+  color-scheme: light;
+}
+
+.dark input[type="date"] {
+  color-scheme: dark;
+}


### PR DESCRIPTION
## Summary
- ensure native date pickers respect theme

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6846b1b5aacc8329a247690852335664