### PR TITLE
Add vitest configuration for web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ pnpm dev
 | `pnpm dev`   | Run all dev servers        |
 | `pnpm build` | Build all apps/packages    |
 | `pnpm lint`  | Lint all workspaces        |
-| `pnpm test`  | Run all tests (future use) |
+| `pnpm test`  | Run all tests             |
 
 ---
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.10",
@@ -48,6 +49,9 @@
     "tw-animate-css": "^1.3.4",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.4.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.2"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
@@ -54,7 +54,7 @@
     "vite": "^6.3.5",
     "vitest": "^1.4.0",
     "@testing-library/react": "^14.2.1",
-    "@testing-library/jest-dom": "^6.4.2"
+    "@testing-library/jest-dom": "^6.4.2",
     "@storybook/react-vite": "^8.0.0"
   }
 }

--- a/apps/web/src/components/ui/button.test.tsx
+++ b/apps/web/src/components/ui/button.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react'
+import { Button } from './button'
+import { describe, it, expect } from 'vitest'
+
+describe('Button', () => {
+  it('renders children', () => {
+    const { getByText } = render(<Button>Click me</Button>)
+    expect(getByText('Click me')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/setupTests.ts
+++ b/apps/web/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,7 +2,8 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.vitest.json" }
   ],
   "compilerOptions": {
     "baseUrl": ".",

--- a/apps/web/tsconfig.vitest.json
+++ b/apps/web/tsconfig.vitest.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/setupTests.ts',
+  },
+})

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "turbo run dev",
     "dev:desktop": "pnpm --filter @resumier/desktop tauri dev",
     "dev:mobile": "pnpm --filter @resumier/mobile start",
-    "dev:web": "pnpm --filter @resumier/web dev",
+    "dev:web": "pnpm --filter @resumier/web dev"
   },
   "devDependencies": {
     "turbo": "^2.5.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "turbo run build",
     "lint": "turbo run lint",
-    "test": "turbo run test"
+    "test": "turbo run test",
     "dev": "turbo run dev",
     "dev:desktop": "pnpm --filter @resumier/desktop tauri dev",
     "dev:mobile": "pnpm --filter @resumier/mobile start",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev:desktop": "pnpm --filter @resumier/desktop tauri dev",
     "dev": "turbo run dev",
     "build": "turbo run build",
-    "lint": "turbo run lint"
+    "lint": "turbo run lint",
+    "test": "turbo run test"
   },
   "devDependencies": {
     "turbo": "^2.5.0"


### PR DESCRIPTION
## Summary
- configure vitest for `apps/web`
- add sample Button test
- wire up test script in root and README

## Related Issues

## Checklist
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes


------
https://chatgpt.com/codex/tasks/task_e_6846bb3ef7e883299f3867fc80ba7561