### PR TITLE
Fix padding in personal info dialog

### DIFF
--- a/apps/web/src/components/personal-info-dialog.tsx
+++ b/apps/web/src/components/personal-info-dialog.tsx
@@ -158,7 +158,7 @@ export function PersonalInfoDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="overflow-hidden p-0 md:max-h-[600px] md:max-w-[800px]">
+      <DialogContent className="overflow-hidden md:max-h-[600px] md:max-w-[800px]">
         <DialogHeader>
           <DialogTitle>Personal Information</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
## Summary
- add default padding in the personal info dialog so content isn't flush with edges

## Testing
- `pnpm lint`
- `pnpm test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_6846bfc1f4dc8329ada87cd8670cad5a