### PR TITLE
Limit workflow triggers

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -2,7 +2,7 @@ name: Add PRs to Resumier project
 
 on:
   pull_request_target:
-    types: [opened, reopened, ready_for_review, synchronize]
+    types: [opened, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -1,7 +1,7 @@
 name: Auto assign PR author
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
+    types: [opened, reopened, ready_for_review]
 jobs:
   add-author:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- only add PRs to project when opened, reopened or ready for review
- only auto-assign author on opened, reopened or ready for review

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6846c20072ac8329beb3267c937728e0