### PR TITLE
Adjust workflow triggers

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,6 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [main]
   pull_request:
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,6 @@
 name: Lint
 
 on:
-  push:
-    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,9 +1,6 @@
 name: SonarQube
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:


### PR DESCRIPTION
## Summary
- only trigger the CodeQL, lint, and SonarQube workflows on `pull_request`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6847aa9ee27c8329baf639b7a55eb86d