### PR TITLE
Switch to GitHub security issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/security_report.md
+++ b/.github/ISSUE_TEMPLATE/security_report.md
@@ -1,0 +1,19 @@
+---
+name: Security report
+about: Report a security vulnerability
+title: "[Security]: "
+labels: security
+assignees: ''
+---
+
+**Describe the vulnerability**
+A clear and concise description of the issue.
+
+**Steps To Reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+What you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -6,5 +6,5 @@ Only the latest stable release of Resumier is currently supported. Please update
 
 ## Reporting a Vulnerability
 
-If you discover a security issue, please email security@example.com with the details.
-We ask that you do not publicly disclose the issue before we have a chance to address it.
+If you discover a security issue, please [open a security report](../../issues/new?template=security_report.md) using our "Security report" issue template.
+Do not publicly disclose the vulnerability before we have a chance to address it.


### PR DESCRIPTION
## Summary
- guide users to open a security issue instead of sending email
- add a security issue template

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6847cd4460b88329b15f87bf28e58de2