### PR TITLE
Add additional unit tests

### DIFF
--- a/apps/web/src/components/ui/badge.test.tsx
+++ b/apps/web/src/components/ui/badge.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react'
+import { Badge } from './badge'
+import { describe, it, expect } from 'vitest'
+
+describe('Badge', () => {
+  it('applies variant classes', () => {
+    const { getByText } = render(<Badge variant="destructive">Alert</Badge>)
+    const el = getByText('Alert')
+    expect(el.className).toContain('bg-destructive')
+  })
+
+  it('renders as child element when asChild is true', () => {
+    const { container } = render(
+      <Badge asChild>
+        <a href="#">Link</a>
+      </Badge>
+    )
+    const anchor = container.querySelector('a')
+    expect(anchor).not.toBeNull()
+    expect(anchor?.getAttribute('data-slot')).toBe('badge')
+  })
+})

--- a/apps/web/src/components/ui/button.test.tsx
+++ b/apps/web/src/components/ui/button.test.tsx
@@ -7,4 +7,22 @@ describe('Button', () => {
     const { getByText } = render(<Button>Click me</Button>)
     expect(getByText('Click me')).toBeInTheDocument()
   })
+
+  it('forwards className from variants', () => {
+    const { getByText } = render(
+      <Button variant="destructive">Delete</Button>
+    )
+    expect(getByText('Delete').className).toContain('bg-destructive')
+  })
+
+  it('supports rendering as child element', () => {
+    const { container } = render(
+      <Button asChild>
+        <a href="#">A</a>
+      </Button>
+    )
+    const anchor = container.querySelector('a')
+    expect(anchor).not.toBeNull()
+    expect(anchor?.getAttribute('data-slot')).toBe('button')
+  })
 })

--- a/apps/web/src/components/ui/card.test.tsx
+++ b/apps/web/src/components/ui/card.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react'
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from './card'
+import { describe, it, expect } from 'vitest'
+
+describe('Card', () => {
+  it('renders all subcomponents', () => {
+    const { getByText, getByTestId } = render(
+      <Card>
+        <CardHeader data-testid="header">
+          <CardTitle>Title</CardTitle>
+        </CardHeader>
+        <CardContent data-testid="content">Body</CardContent>
+        <CardFooter data-testid="footer">Footer</CardFooter>
+      </Card>
+    )
+    expect(getByTestId('header').getAttribute('data-slot')).toBe('card-header')
+    expect(getByText('Title').getAttribute('data-slot')).toBe('card-title')
+    expect(getByTestId('content').getAttribute('data-slot')).toBe('card-content')
+    expect(getByTestId('footer').getAttribute('data-slot')).toBe('card-footer')
+  })
+})

--- a/apps/web/src/components/ui/use-sidebar.test.tsx
+++ b/apps/web/src/components/ui/use-sidebar.test.tsx
@@ -1,0 +1,27 @@
+import { renderHook } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { useSidebar, SidebarContext } from './use-sidebar'
+
+describe('useSidebar', () => {
+  it('throws when used outside provider', () => {
+    const { result } = renderHook(() => useSidebar())
+    expect(result.error).toBeInstanceOf(Error)
+  })
+
+  it('returns context when inside provider', () => {
+    const context = {
+      state: 'expanded',
+      open: true,
+      setOpen: vi.fn(),
+      openMobile: false,
+      setOpenMobile: vi.fn(),
+      isMobile: false,
+      toggleSidebar: vi.fn(),
+    }
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <SidebarContext.Provider value={context}>{children}</SidebarContext.Provider>
+    )
+    const { result } = renderHook(() => useSidebar(), { wrapper })
+    expect(result.current).toBe(context)
+  })
+})

--- a/apps/web/src/hooks/use-mobile.test.ts
+++ b/apps/web/src/hooks/use-mobile.test.ts
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useIsMobile } from './use-mobile'
+
+function setup(width: number) {
+  Object.defineProperty(window, 'innerWidth', { writable: true, value: width })
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockReturnValue({
+      matches: width < 768,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  })
+}
+
+describe('useIsMobile', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('detects mobile width', () => {
+    setup(500)
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(true)
+  })
+
+  it('detects desktop width', () => {
+    setup(1024)
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(false)
+  })
+})

--- a/apps/web/src/hooks/use-resume-store.test.ts
+++ b/apps/web/src/hooks/use-resume-store.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('idb-keyval', () => ({
+  get: vi.fn(() => Promise.resolve(null)),
+  set: vi.fn(() => Promise.resolve()),
+  del: vi.fn(() => Promise.resolve()),
+}))
+
+import { useResumeStore } from './use-resume-store'
+
+beforeEach(() => {
+  useResumeStore.setState({ userInfo: {}, jobInfo: {}, jobs: [], content: {} })
+})
+
+describe('useResumeStore', () => {
+  it('adds a job', () => {
+    useResumeStore.getState().addJob({ title: 'Engineer' })
+    const state = useResumeStore.getState()
+    expect(state.jobs).toHaveLength(1)
+    expect(state.jobs[0].title).toBe('Engineer')
+  })
+
+  it('resets state', () => {
+    useResumeStore.getState().setUserInfo({ name: 'Alice' })
+    useResumeStore.getState().reset()
+    const state = useResumeStore.getState()
+    expect(state.userInfo).toEqual({})
+    expect(state.jobs).toHaveLength(0)
+  })
+
+  it('removes a job by index', () => {
+    const store = useResumeStore.getState()
+    store.addJob({ title: 'A' })
+    store.addJob({ title: 'B' })
+    store.removeJob(0)
+    expect(store.jobs).toHaveLength(1)
+    expect(store.jobs[0].title).toBe('B')
+  })
+
+  it('updates user info', () => {
+    const store = useResumeStore.getState()
+    store.setUserInfo({ name: 'Bob' })
+    expect(store.userInfo).toEqual({ name: 'Bob' })
+  })
+})

--- a/apps/web/src/hooks/use-theme.test.ts
+++ b/apps/web/src/hooks/use-theme.test.ts
@@ -1,0 +1,46 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from 'vitest'
+import { useTheme } from './use-theme'
+
+let originalMatchMedia: typeof window.matchMedia
+
+beforeAll(() => {
+  originalMatchMedia = window.matchMedia
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  })
+})
+
+afterAll(() => {
+  window.matchMedia = originalMatchMedia
+})
+
+describe('useTheme', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.className = ''
+  })
+
+  it('initializes from localStorage', () => {
+    localStorage.setItem('theme', 'dark')
+    const { result } = renderHook(() => useTheme())
+    expect(result.current.theme).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('toggles theme', () => {
+    const { result } = renderHook(() => useTheme())
+    act(() => {
+      result.current.toggleTheme()
+    })
+    expect(result.current.theme).toBe('dark')
+    expect(localStorage.getItem('theme')).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+})

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from './utils'
+
+describe('cn', () => {
+  it('merges tailwind classes', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+  })
+
+  it('ignores falsy values', () => {
+    expect(cn('p-2', null, undefined, false, 'text-center')).toBe('p-2 text-center')
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for `Badge` variants and asChild rendering
- add `Card` component tests for subcomponent slots
- expand `Button` tests to cover variants and asChild
- extend `useResumeStore` tests for removing jobs and setting user info

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find dependency 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6847f5e5d2088329a72e37dcff5a5c4c