### PR TITLE
Fix proficiency dropdown theme

### DIFF
--- a/apps/web/src/components/job-info-dialog.tsx
+++ b/apps/web/src/components/job-info-dialog.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Select } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import {
   Sidebar,
@@ -131,9 +132,8 @@ export function JobInfoDialog({
                 </div>
                 <div className="grid gap-2">
                   <Label htmlFor="workType">Type of Work</Label>
-                  <select
+                  <Select
                     id="workType"
-                    className="border rounded-md p-2"
                     value={workType}
                     onChange={(e) => setWorkType(e.target.value)}
                   >
@@ -141,7 +141,7 @@ export function JobInfoDialog({
                     <option value="onsite">Onsite</option>
                     <option value="remote">Remote</option>
                     <option value="hybrid">Hybrid</option>
-                  </select>
+                  </Select>
                 </div>
                 <div className="grid gap-2">
                   <Label htmlFor="location">Location</Label>

--- a/apps/web/src/components/personal-info/skills-section.tsx
+++ b/apps/web/src/components/personal-info/skills-section.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Select } from "@/components/ui/select"
 import type { Skill } from "@/hooks/use-resume-store"
 import { Plus, Trash } from "lucide-react"
 
@@ -36,8 +37,7 @@ export function SkillsSection({ skills, addSkill, updateSkill, removeSkill }: Sk
           </div>
           <div className="grid gap-2">
             <Label>Proficiency</Label>
-            <select
-              className="border rounded-md p-2"
+            <Select
               value={skill.proficiency ?? ""}
               onChange={(e) => updateSkill(i, "proficiency", e.target.value)}
             >
@@ -54,7 +54,7 @@ export function SkillsSection({ skills, addSkill, updateSkill, removeSkill }: Sk
                   </option>
                 )
               })}
-            </select>
+            </Select>
           </div>
           <Button type="button" variant="outline" size="sm" onClick={() => removeSkill(i)}>
             <Trash className="mr-2 h-4 w-4" /> Remove

--- a/apps/web/src/components/ui/select.stories.tsx
+++ b/apps/web/src/components/ui/select.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Select } from "./select";
+
+const meta: Meta<typeof Select> = {
+  title: "ui/Select",
+  component: Select,
+  tags: ["autodocs"],
+};
+export default meta;
+
+type Story = StoryObj<typeof Select>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Select({ className, ...props }: React.ComponentProps<"select">) {
+  return (
+    <select
+      data-slot="select"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Select }


### PR DESCRIPTION
## Summary
- add theme-aware Select component
- use Select in skill sections and job dialog
- document Select in Storybook

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68480c2abe748329a21160b371db59a9