### PR TITLE
Fix rendering skills

### DIFF
--- a/apps/web/src/components/resume-builder.tsx
+++ b/apps/web/src/components/resume-builder.tsx
@@ -61,7 +61,7 @@ export function ResumeBuilder() {
           <ul className="flex flex-wrap gap-2">
             {skills.map((skill, i) => (
               <li key={i} className="border px-2 py-1 rounded text-sm">
-                {skill}
+                {typeof skill === "string" ? skill : skill.name}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- ensure skill objects are rendered by name in ResumeBuilder

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684814a99ae88329ae0ab170b97ff40c