### PR TITLE
Fix sidebar hook test compilation

### DIFF
--- a/apps/web/src/components/ui/use-sidebar.test.tsx
+++ b/apps/web/src/components/ui/use-sidebar.test.tsx
@@ -1,15 +1,15 @@
 import { renderHook } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import { useSidebar, SidebarContext } from './use-sidebar'
+import type { SidebarContextProps } from './use-sidebar'
 
 describe('useSidebar', () => {
   it('throws when used outside provider', () => {
-    const { result } = renderHook(() => useSidebar())
-    expect(result.error).toBeInstanceOf(Error)
+    expect(() => renderHook(() => useSidebar())).toThrowError()
   })
 
   it('returns context when inside provider', () => {
-    const context = {
+    const context: SidebarContextProps = {
       state: 'expanded',
       open: true,
       setOpen: vi.fn(),


### PR DESCRIPTION
## Summary
- update tests for updated renderHook typings

## Testing
- `pnpm lint`
- `pnpm --filter @resumier/web build`

------
https://chatgpt.com/codex/tasks/task_e_68489d07087c8329aa104d04d097b110