### PR TITLE
Fix base path for GH Pages

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,10 +4,11 @@ import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 
 export default defineConfig({
+  base: '/Resumier/',
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      '@': path.resolve(__dirname, './src'),
     },
   },
 })


### PR DESCRIPTION
## Summary
- set Vite base path so assets load when hosted via GitHub Pages

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6848eafa7c9483299d85803177466ae0