### PR TITLE
feat(web): add dashboard page

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,38 +7,53 @@ import {
   SidebarRail,
 } from "@/components/ui/sidebar"
 import { ResumeBuilder } from "@/components/resume-builder"
+import { ResumeDashboard } from "@/components/resume-dashboard"
 import { PersonalInfoDialog } from "@/components/personal-info-dialog"
 import { JobInfoDialog } from "@/components/job-info-dialog"
 import { AppHeader } from "@/components/app-header"
+import { useResumeDocuments } from "@/hooks/use-resume-documents"
 
 
 export default function App() {
   const [openPersonal, setOpenPersonal] = useState(false)
   const [openJob, setOpenJob] = useState(false)
+  const [page, setPage] = useState<'dashboard' | 'builder'>('dashboard')
+  const documents = useResumeDocuments((s) => s.documents)
+  const addDocument = useResumeDocuments((s) => s.addDocument)
 
-  return (
+  function handleCreateResume() {
+    const id =
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : Math.random().toString(36).slice(2)
+    addDocument({ id, name: `Resume ${documents.length + 1}` })
+    setPage('builder')
+  }
+
+  return page === 'dashboard' ? (
+    <div className="min-h-screen flex flex-col">
+      <h1 className="text-2xl font-bold p-4">Resumes</h1>
+      <ResumeDashboard onCreateResume={handleCreateResume} />
+    </div>
+  ) : (
     <div className="min-h-screen flex flex-col">
       <AppHeader
         onPersonalInfoClick={() => setOpenPersonal(true)}
         onJobInfoClick={() => setOpenJob(true)}
+        onBackClick={() => setPage('dashboard')}
       />
       <SidebarProvider className="flex flex-1 mt-16">
-      {/* Left Sidebar */}
-      <Sidebar side="left" collapsible="icon">
-        <SidebarRail />
-        <SidebarContent className="p-4 text-sm">Left Sidebar</SidebarContent>
-      </Sidebar>
-
-      {/* Main Content Area */}
-      <SidebarInset>
-        <div className="flex flex-col flex-1 min-h-0">
-          <div className="flex-1 overflow-auto p-4 flex items-start justify-center">
-            <ResumeBuilder />
+        <Sidebar side="left" collapsible="icon">
+          <SidebarRail />
+          <SidebarContent className="p-4 text-sm">Left Sidebar</SidebarContent>
+        </Sidebar>
+        <SidebarInset>
+          <div className="flex flex-col flex-1 min-h-0">
+            <div className="flex-1 overflow-auto p-4 flex items-start justify-center">
+              <ResumeBuilder />
+            </div>
           </div>
-        </div>
-      </SidebarInset>
-
-      {/* Right Sidebar */}
+        </SidebarInset>
         <Sidebar side="right" collapsible="icon">
           <SidebarRail />
           <SidebarContent className="p-4 text-sm">Right Sidebar</SidebarContent>
@@ -49,3 +64,4 @@ export default function App() {
     </div>
   )
 }
+

--- a/apps/web/src/components/app-header.tsx
+++ b/apps/web/src/components/app-header.tsx
@@ -1,17 +1,25 @@
 import { Button } from "@/components/ui/button"
 import { ThemeToggle } from "@/components/theme-toggle"
+import { ArrowLeft } from "lucide-react"
 
 export function AppHeader({
   onPersonalInfoClick,
   onJobInfoClick,
+  onBackClick,
 }: {
   onPersonalInfoClick?: () => void
   onJobInfoClick?: () => void
+  onBackClick?: () => void
 }) {
   return (
     <header className="fixed inset-x-0 top-0 z-20 flex h-16 items-center justify-between gap-4 border-b bg-background px-4">
       <div className="flex items-center gap-2">
         <img src={`${import.meta.env.BASE_URL}logo_dark.png`} alt="Logo" className="h-8" />
+        {onBackClick && (
+          <Button variant="ghost" size="sm" onClick={onBackClick} className="ml-2">
+            <ArrowLeft className="size-4 mr-1" /> Dashboard
+          </Button>
+        )}
       </div>
       <h1 className="flex-1 text-center text-lg font-semibold">Resume</h1>
       <nav className="flex gap-2">

--- a/apps/web/src/components/resume-dashboard.tsx
+++ b/apps/web/src/components/resume-dashboard.tsx
@@ -1,0 +1,30 @@
+import { Plus } from "lucide-react"
+import { useResumeDocuments } from "@/hooks/use-resume-documents"
+import { Card, CardHeader, CardTitle } from "@/components/ui/card"
+
+export function ResumeDashboard({
+  onCreateResume,
+}: {
+  onCreateResume: () => void
+}) {
+  const documents = useResumeDocuments((state) => state.documents)
+
+  return (
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-4 p-4">
+      {documents.map((doc) => (
+        <Card key={doc.id} className="cursor-pointer">
+          <CardHeader>
+            <CardTitle>{doc.name}</CardTitle>
+          </CardHeader>
+        </Card>
+      ))}
+      <div
+        onClick={onCreateResume}
+        className="border-dashed border-2 rounded-lg flex flex-col items-center justify-center cursor-pointer py-8 text-muted-foreground hover:bg-accent"
+      >
+        <Plus className="size-8" />
+        <span className="mt-2">New Resume</span>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/hooks/use-resume-documents.ts
+++ b/apps/web/src/hooks/use-resume-documents.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand"
+import { persist, createJSONStorage } from "zustand/middleware"
+
+export interface ResumeDocument {
+  id: string
+  name: string
+}
+
+interface DocumentsState {
+  documents: ResumeDocument[]
+  addDocument: (doc: ResumeDocument) => void
+}
+
+export const useResumeDocuments = create<DocumentsState>()(
+  persist(
+    (set) => ({
+      documents: [],
+      addDocument: (doc) =>
+        set((state) => ({ documents: [...state.documents, doc] })),
+    }),
+    {
+      name: "resumier-documents",
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+)


### PR DESCRIPTION
## Summary
- add zustand store for resume documents
- create Dashboard component with plus placeholder
- update header to support going back to dashboard
- switch `App` to render dashboard and builder

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68490c4062208329a0eed08d33b12f8f